### PR TITLE
Add missing l10n

### DIFF
--- a/src/plugins/KeyUtils/intl/en.txt
+++ b/src/plugins/KeyUtils/intl/en.txt
@@ -12,6 +12,7 @@ ConfigToadlet.plugins.KeyUtils.KeyUtilsPlugin.tooltip=default settings for KeyUt
 Donate.title=Donate
 Donate.tooltip=How to donate
 ExtraCalculator.PageTitel=Key Utility Suite - Extra Calculator
+FBlobViewer.PageTitle=Key Utility Suite - FBlob Viewer
 KeyKonverter.PageTitle=Key Utility Suite - Key Converter
 KeyExplorer.PageTitle=Key Utility Suite - Key Explorer
 Menu.About.title=About


### PR DESCRIPTION
Fixes:
The default translation for FBlobViewer.PageTitle hasn't been found!
java.lang.Exception
    at freenet.l10n.BaseL10n.getDefaultString(BaseL10n.java:445)
    at freenet.l10n.BaseL10n.getString(BaseL10n.java:407)
    at freenet.l10n.BaseL10n.getString(BaseL10n.java:380)
    at plugins.KeyUtils.toadlets.FBlobToadlet.i18n(FBlobToadlet.java:164)
    at plugins.KeyUtils.toadlets.FBlobToadlet.makeMainPage(FBlobToadlet.java:69)
    at plugins.KeyUtils.toadlets.FBlobToadlet.handleMethodGET(FBlobToadlet.java:47)
...
