### PR TITLE
Fix extra bytes display for composed SSK

### DIFF
--- a/src/main/java/plugins/KeyUtils/toadlets/ExtraToadlet.java
+++ b/src/main/java/plugins/KeyUtils/toadlets/ExtraToadlet.java
@@ -254,7 +254,7 @@ public class ExtraToadlet extends WebInterfaceToadlet {
 			} catch (NumberFormatException nfe) {
 				errors.add("Field 'type' must be a number 1 - 255)");
 			}
-			extra[1] = (byte) (s_private.length()>0 ? 2 : 0);
+			extra[1] = (byte) (s_private.length()>0 ? 1 : 0);
 			try {
 				extra[2] = Byte.parseByte(s_crypto);
 			} catch (NumberFormatException nfe) {


### PR DESCRIPTION
Fix for composed private SSK displaying as AQICAAE instead of AQECAAE.