### PR TITLE
Fix API call to allow compiling

### DIFF
--- a/src/main/java/plugins/KeyUtils/KeyExplorerUtils.java
+++ b/src/main/java/plugins/KeyUtils/KeyExplorerUtils.java
@@ -206,7 +206,7 @@ public class KeyExplorerUtils {
 					}
 
 					output = finalResult.getOutputStream();
-					worker = new ClientGetWorkerThread(dataInput, output, null, null, null, false, ctx.charset, ctx.prefetchHook, ctx.tagReplacer, null);
+					worker = new ClientGetWorkerThread(dataInput, output, null, null, null, null, false, ctx.charset, ctx.prefetchHook, ctx.tagReplacer, null);
 					worker.start();
 					try {
 						streamGenerator.writeTo(dataOutput, context);


### PR DESCRIPTION
For some reason there was a wrong number of parameters being passed to ClientGetWorkerThread()
Regardless of which of the 4 params was missing, they seem to all be able to be null safely.